### PR TITLE
CHG: Added numeric base modifier to ensure decimal base.

### DIFF
--- a/src/res2h.cpp
+++ b/src/res2h.cpp
@@ -388,8 +388,8 @@ bool convertFile(FileData & fileData, const boost::filesystem::path & commonHead
 				fileData.dataVariableName = fileData.outPath.filename().stem().string() + "_data";
 				fileData.sizeVariableName = fileData.outPath.filename().stem().string() + "_size";
 				//add size and data variable
-				outStream << "const size_t " << fileData.sizeVariableName << " = " << fileData.size << ";" << std::endl;
-				outStream << "const unsigned char " << fileData.dataVariableName << "[" << fileData.size << "] = {" << std::endl;
+				outStream << "const size_t " << fileData.sizeVariableName << " = " << std::dec << fileData.size << ";" << std::endl;
+				outStream << "const unsigned char " << fileData.dataVariableName << "[" << std::dec << fileData.size << "] = {" << std::endl;
 				outStream << "    "; //first indent
 				//now add content
 				size_t breakCounter = 0;


### PR DESCRIPTION
This solves a problem I encountered, which lead to array sizes being printed with hexadecimal numeric base.
The pull request ensures that a decimal numeric base is used.